### PR TITLE
Address from HEX file, calculating the checksum.

### DIFF
--- a/TPI_Programmer.ino
+++ b/TPI_Programmer.ino
@@ -66,6 +66,7 @@
    Feb 12, 2024: petrov@email.su
        * Address from HEX file.
        * Small editing for convenience.
+	   * Added checksum calculation.
    Feb 24, 2023: KW
        * Simplified HV programming
        * Added dumpConfig() to make the set/clear flag functions more intuitive

--- a/TPI_Programmer.ino
+++ b/TPI_Programmer.ino
@@ -64,7 +64,8 @@
  **************************************************
  Updates:
    Feb 12, 2024: petrov@email.su
-       * 
+       * Address from HEX file.
+       * Small editing for convenience.
    Feb 24, 2023: KW
        * Simplified HV programming
        * Added dumpConfig() to make the set/clear flag functions more intuitive

--- a/TPI_Programmer.ino
+++ b/TPI_Programmer.ino
@@ -188,14 +188,14 @@ void setup(){
   // set up serial
   Serial.begin(9600); // you cant increase this, it'll overrun the buffer
 
-	if (HVP) {
-		digitalWrite(HVReset, HVON);
+	
+		digitalWrite(HVReset, !HVON);
 		pinMode(HVReset, OUTPUT);	
-	}
-	else {
-		digitalWrite(SS, SSN);
+	
+	
+		digitalWrite(SS, !SSN);
 		pinMode(SS, OUTPUT);
-	}
+	
   
 
 delay(1000);

--- a/TPI_Programmer.ino
+++ b/TPI_Programmer.ino
@@ -638,6 +638,7 @@ boolean writeProgram(){
               Serial.print(F(" read "));
               outHex(b,2);
               Serial.println();
+			  eraseChip();
               return false;
             }
           }
@@ -671,6 +672,7 @@ boolean writeProgram(){
       Serial.println(someth, HEX);
       Serial.print(F("The calculated checksum - "));
       Serial.println(checkSum, HEX);
+	  eraseChip();
       return false;
     }
   }
@@ -709,7 +711,7 @@ void eraseChip(){
   while((readIO(NVMCSR) & (1<<7)) != 0x00){
     // wait for erasing to finish
   }
-  Serial.println(F("chip erased"));
+  Serial.println(F("Chip erased."));
 }
 
 void setConfig(boolean val){

--- a/TPI_Programmer.ino
+++ b/TPI_Programmer.ino
@@ -128,7 +128,7 @@
 
 #include <SPI.h>
 #include "pins_arduino.h"
-char HVP = true; // is high voltage programming on by default?
+char HVP = false; // is high voltage programming on by default?
 char HVON = HIGH;    // what is the active level for high voltage programming?
 const char SSN = LOW;    // what is the active level for SS (reset)?
 


### PR DESCRIPTION
I noticed that verification does not pass in the process of the checking microcontroller in the Microchip Studio, if microcontroller was programmed in Arduino-TPI-Programmer. Added checksum calculation.

After Arduino-TPI-Programmer:

    +0 +1 +2 +3 +4 +5 +6 +7 +8 +9 +A +B +C +D +E +F
    4000: 0A C0 18 95 00 C0 2F EF 18 95 0B B7 03 FF 08 C0
    4010: A8 95 07 7F 0B BF 08 ED 0C BF 00 27 01 BF 02 C0
    4020: 00 FF 24 C0 00 27 0B BF 00 E0 0E BF 0F E5 0D BF
    4030: 09 9A 00 E9 0F BB 03 E0 05 BF 08 ED 0C BF 00 27
    .........................................................................................................................
    The same after Microchip Studio:
    +0 +1 +2 +3 +4 +5 +6 +7 +8 +9 +A +B +C +D +E +F
    4000: 0A C0 18 95 FF FF FF FF FF FF FF FF FF FF FF FF
    4010: 00 C0 2F EF 18 95 0B B7 03 FF 08 C0 A8 95 07 7F
    4020: 0B BF 08 ED 0C BF 00 27 01 BF 02 C0 00 FF 24 C0
    4030: 00 27 0B BF 00 E0 0E BF 0F E5 0D BF 09 9A 00 E9